### PR TITLE
Configure google analytics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,6 @@ languageCode: en-us
 title: DHTech
 enableRobotsTXT: true
 
-
 menu:
   main:
   - name: about
@@ -67,3 +66,4 @@ params:
   mobileNavigation: right
   showReadTime: false
   showShare: false
+  ga_analytics: G-P55LD1R62C


### PR DESCRIPTION
the clarity theme has support for google analytics as well as plausible and others - https://github.com/chipzoller/hugo-clarity#global-parameters

adding a config for our existing google analytics property in case we want to use it