### PR TITLE
configure hugo to use lowercase urls; add aliases for existing urls that will change 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 baseURL: http://dh-tech.github.io
-disablePathToLower: true
+disablePathToLower: false
 languageCode: en-us
 title: DHTech
 enableRobotsTXT: true

--- a/content/SIG.md
+++ b/content/SIG.md
@@ -1,6 +1,7 @@
 ---
 title: ADHO Special Interest Group
 description: Steering Committee and Governance
+url: /SIG/
 ---
 
 ## Steering Committee

--- a/content/SIG.md
+++ b/content/SIG.md
@@ -2,6 +2,8 @@
 title: ADHO Special Interest Group
 description: Steering Committee and Governance
 url: /SIG/
+aliases:
+  - /sig/
 ---
 
 ## Steering Committee

--- a/content/blog/2020-08-14-damerow-emails.md
+++ b/content/blog/2020-08-14-damerow-emails.md
@@ -13,6 +13,7 @@ tags:
 - ADayInTheLifeOf
 aliases:
 - /blog/2020-08-14-damerow-emails/
+- /blog/2020/08/14/Just-sending-email-notifications/
 ---
 
 I work as a scientific software engineer at Arizona State University (ASU). I head the [Digital Innovation Group](http://diging.asu.edu/) (or short DigInG) that develops software for historians and philosophers of science. I started this group when I was a graduate student together with another PhD student and besides a pause of about a year when I was working outside of academia after I graduated, DigInG has been a big part of my work life. Besides me, the group consists of one other software engineer and between ten to fifteen student workers. Our student workers help with software development and research related tasks such as data collection, annotation, etc.

--- a/content/blog/2020-08-14-vogl-django.md
+++ b/content/blog/2020-08-14-vogl-django.md
@@ -10,8 +10,10 @@ date: 2020-08-14T09:33:00
 title: Simply updating the Django version ...
 tags: 
 - ADayInTheLifeOf
+slug: updating-django-version
 aliases:
 - /blog/2020-08-14-vogl-django/
+- /blog/2020/08/14/Simply-updating-the-Django-version-.../
 ---
 
 Doing the sensible thing, as a first step I updated to the latest Django version, which was 3.1 at that time. Trying the debugging server of Django just gave me lots of errors. After a short search I realized, that of course also Django CMS needs to be updated, which was done in a breeze. Retrying the server, lots of new interesting errors.

--- a/content/blog/2020-08-17-zope-2-10-in-docker-or-applied-software-archaeology.md
+++ b/content/blog/2020-08-17-zope-2-10-in-docker-or-applied-software-archaeology.md
@@ -9,8 +9,10 @@ thumbnail: /images/uploads/screenshot-old-zope.png
 featureImage: /images/uploads/screenshot-old-zope.png
 featureImageAlt: screenshot of Zope documentation
 summary: I wanted to migrate the old website on the server to a Docker image for Zope so I could use it in a docker-compose setup together with a standard PostgreSQL container. How hard could that be?
+slug: zope-in-docker
 aliases:
 - /blog/2020-08-17-zope-2-10-in-docker-or-applied-software-archaeology/ 
+- /blog/2020/08/17/Zope-2.10-in-Docker-or-Applied-Software-Archaeology/
 ---
 
 During the COVID-19 lockdown in March 2020 I was in my home office and I was reading all those stories on Twitter of people who suddenly learned painting or playing the guitar and I envied them for the time and energy for something new they seemed to have. My personal work situation felt pretty much the same except for the missing commute to our institute, but I decided to use some time to look at some of our old projects on our old servers and either migrate or delete the websites and shut down the servers. This suddenly felt creative and refreshing like a spring cleaning with Marie Condo.

--- a/content/blog/2020-11-26-sharing-users-between-django-projects.md
+++ b/content/blog/2020-11-26-sharing-users-between-django-projects.md
@@ -13,6 +13,7 @@ summary: You should never share Django user databases between projects! But
   sometimes....
 aliases:
 - /blog/2020-11-26-sharing-users-between-django-projects/
+- /blog/2020/11/26/Sharing-Users-between-Django-projects/
 ---
 
 For a small project we had two Django instances dealing with different parts of a workflow. Since the system was supposed to run on an air-gapped sub-system of the infrastructure, our usual authentification and authorization approach using OpenIDConnect was no option. 

--- a/content/blog/2021-04-14-dhtech-on-twitter.md
+++ b/content/blog/2021-04-14-dhtech-on-twitter.md
@@ -11,6 +11,7 @@ featureImageCap: "via @Lorem Picsum"
 summary: DHtech is now tweeting @dhtech_group
 aliases:
 - /blog/2021-04-14-dhtech-on-twitter/
+- /blog/2021/04/14/DHtech-on-Twitter/
 ---
 
 DHtech is joining the crowd on Twitter with the handle @dhtech_group. We will be using the account for announcing our activities and events. 

--- a/content/blog/2021-09-30-dhtech-meetup.md
+++ b/content/blog/2021-09-30-dhtech-meetup.md
@@ -16,6 +16,7 @@ summary: "The first DHTech Meetup as a SIG took place on 29th of
   movement. "
 aliases:
 - /blog/2021-09-30-dhtech-meetup/
+- /blog/2021/09/30/First-DHtech-Meetup-as-an-ADHO-SIG/
 ---
 The SIG activities that were discussed include the new mentorship program, which will offer a long term, low frequency partnership between members working on various DH topics; and a community code review initiative, which aims to improve the code quality of DH projects. 
 

--- a/content/blog/2021-12-21-greatly-improved-dh-link-list.md
+++ b/content/blog/2021-12-21-greatly-improved-dh-link-list.md
@@ -14,6 +14,7 @@ summary: "Thanks to Moritz Maehr, DHTech now has a vastly improved list of
   tips for resources and tools as a pull request! "
 aliases:
 - /blog/2021-12-21-greatly-imporved-dh-link-list/
+- /blog/2021/12/21/Greatly-improved-DH-link-list/
 ---
 [Moritz Mähr](https://github.com/maehr) kindly offered to merge his external Digital History link list with our admittedly outdated awesome-dhtools list. He also included Github actions to make the list a member of the [awesome lists ecosystem](https://github.com/sindresorhus/awesome). The much improved list can now be accessed at [dh-tech.github.io/awesome-dhtools/](https://dh-tech.github.io/awesome-dhtools/)
 

--- a/content/blog/2022-03-23-a-code-review-process-for-dh.md
+++ b/content/blog/2022-03-23-a-code-review-process-for-dh.md
@@ -12,8 +12,10 @@ summary: The Code Review Working Group of DHTech is starting the alpha phase of
   implementing a code review process for the digital humanities. For the initial
   round of reviews, we are looking for people willing to submit code for review
   and people willing to review someone else’s code.
+slug: code-review-for-dh
 aliases:
 - /blog/2022-03-23-a-code-review-process-for-dh/
+- /blog/2022/03/23/A-Code-Review-Process-for-DH/
 ---
 The Code Review Working Group of DHTech is starting the alpha phase of implementing a code review process for the digital humanities. For the initial round of reviews, we are looking for people willing to submit code for review and people willing to review someone else’s code. If you are willing to participate, we will also ask you to complete a feedback questionnaire at the end to help us improve the process. 
 

--- a/content/blog/2022-05-27-awesome-dhtools-maintainer.md
+++ b/content/blog/2022-05-27-awesome-dhtools-maintainer.md
@@ -12,6 +12,7 @@ featureImageCap: via <a href="https://unsplash.com/photos/NL_DF0Klepc">unsplash<
 summary: 'Our "Awesome DHTools" repository has two new maintainers: Moritz Mähr and Diego Siqueira!'
 aliases:
 - /blog/2022-05-27-awesome-dhtools-maintainer/
+- /blog/2022/05/27/Awesome-DHTools-has-new-Maintainers/
 ---
 
 We want to thank [Moritz Mähr](https://github.com/maehr) and [Diego Siqueira](https://github.com/diegosiqueir4) for agreeing to become the official maintainers of our [Awesome DHtools repository](https://dh-tech.github.io/awesome-digital-humanities/). For the last few months they have steadily improved and added to the list. We are grateful that the list is in such capable hands!

--- a/content/blog/2022-12-20-summary-django-meetup.md
+++ b/content/blog/2022-12-20-summary-django-meetup.md
@@ -12,6 +12,7 @@ author: Rebecca Sutton Koeser and Julia Damerow
 summary: Our December meetup was focussed on discussing the Python-based Django framework. Read our summary of the meetup!
 aliases:
 - /blog/2022-12-20-summary-django-meetup/
+- /blog/2022/12/20/DHTech-on-Django/
 ---
 
   

--- a/content/blog/2023-01-16-all-the-color-profile-s-of-java.md
+++ b/content/blog/2023-01-16-all-the-color-profile-s-of-java.md
@@ -15,8 +15,10 @@ featureImageAlt:
 summary: How the digilib image server learned to treat images with color
   profiles correctly and how I learned more about the weird quirks of Java's
   image libraries than ever before.
+slug: java-color-profiles
 aliases:
 - /blog/2023-01-16-all-the-color-profile-s-of-java/
+- /blog/2023/01/16/All-the-colorprofiles-of-Java/
 ---
 I have always been aware that the way that our [digilib](https://github.com/robcast/digilib) image server dealt with images with color profiles -- basically it did nothing -- was not perfect. But now I got a report from a project and some sample images that showed substantially washed-out colors in the image processed by digilib compared to the original image viewed in a desktop image viewer. I had to finally get digilib to do color right.
 

--- a/content/blog/2023-02-09-hackathon-summary.md
+++ b/content/blog/2023-02-09-hackathon-summary.md
@@ -10,8 +10,10 @@ featureImageAlt: angled image of code in a text editor
 featureImageCap: Photo by <a href="https://unsplash.com/@pankajpatel?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Pankaj Patel</a> on <a href="https://unsplash.com/photos/_SgRNwAVNKw?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
 author: Rebecca Sutton Koeser
 summary: Rebecca reflects on the first DHTech Hackathon!
+slug: hackathon-undate
 aliases:
 - /blog/2023-02-09-hackathon-summary/
+- /blog/2023/02/09/Join-me-for-a-DHTech-hackathon-Its-an-un-date/
 ---
 
 In November of last year, DHTech held our first hackathon. I wasn’t sure what to expect from it, but I was excited at the prospect of working on something with other members in the community and creating something together.

--- a/content/blog/2023-08-07-ending-principles.md
+++ b/content/blog/2023-08-07-ending-principles.md
@@ -10,8 +10,10 @@ featureImageCap: Screen capture from the Endings Project website.
 featureImageAlt: "The Endings Project: Building Sustainable Digital Humanities Projects."
 author: Moritz Mähr
 summary: "In the digital realm, ensuring the longevity of projects is crucial. The University of Victoria's \"Endings Project\" presents guidelines for digital project sustainability. These principles divide projects into five areas: Data, Documentation, Processing, Products, and Release Management, each with its own set of standards to assure sustainability."
+slug: endings-principles
 aliases:
 - /blog/2023-08-07-ending-principles/
+- /blog/2023/08/07/Embracing-Endings-Principles-for-Digital-Longevity-and-Their-Importance-for-Research-Software-Engineers/
 ---
 
 In the ever-evolving digital landscape, the concept of digital longevity

--- a/content/blog/2023-08-29-szemes-botond-dh2023.md
+++ b/content/blog/2023-08-29-szemes-botond-dh2023.md
@@ -10,8 +10,10 @@ featureImage: /images/posts/DH2023.png
 featureImageCap: <a href="https://dh2023.adho.org/">DH2023 University of Graz</a>
 author: Szemes Botond
 summary: "Thanks to funding from ADHO, DHTech was able to support one DHTech member by paying for their DH2023 registration costs. Read Szemes Botond reflection of the workshop \"Digital Literary Stylistics (SIG-DLS)\"!"
+slug: dh2023-conference-report
 aliases:
 - /blog/2023-08-29-szemes-botond-dh2023/
+- /blog/2023/08/29/Report-on-a-conference-session-DH2023-Graz/
 ---
 
 *Thanks to funding from ADHO, DHTech was able to support one DHTech member by paying for their DH2023 registration costs. Read Szemes Botond reflection of the workshop "Digital Literary Stylistics (SIG-DLS)"!*

--- a/content/tags/2Simple2Mention/_index.md
+++ b/content/tags/2Simple2Mention/_index.md
@@ -1,0 +1,5 @@
+---
+title: 2Simple2Mention
+aliases:
+ - /tags/2Simple2Mention/
+---

--- a/content/tags/ADayInTheLifeOf/_index.md
+++ b/content/tags/ADayInTheLifeOf/_index.md
@@ -1,0 +1,5 @@
+---
+title: ADayInTheLifeOf
+aliases:
+ - /tags/ADayInTheLifeOf/
+---

--- a/content/tags/WhatsHappening/_index.md
+++ b/content/tags/WhatsHappening/_index.md
@@ -1,0 +1,5 @@
+---
+title: WhatsHappening
+aliases:
+ - /tags/WhatsHappening/
+---

--- a/content/workshops/2018-10-15-CIDOC-CRMbyPractice.md
+++ b/content/workshops/2018-10-15-CIDOC-CRMbyPractice.md
@@ -4,6 +4,8 @@ date: '2018-10-15'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D236-B/data'
 audio: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D235-C/data'
 excerpt: "In this webinar Florian Kräutli showed how to use the [X3ML Toolkit](https://www.ics.forth.gr/isl/index_main.php?l=e&c=721) to build a [CIDOC-CRM model](link to http://www.cidoc-crm.org/) based on existing XML data."
+aliases:
+- /workshops/2018-10-15-CIDOC-CRMbyPractice/
 ---
 
 In this webinar Florian Kräutli showed how to use the [X3ML Toolkit](https://www.ics.forth.gr/isl/index_main.php?l=e&c=721) to build a [CIDOC-CRM model](http://www.cidoc-crm.org/) based on existing XML data. We can then use the same tool to convert the data to RDF and ingest it into a linked data platform. He demonstrated the [Metaphactory](https://www.metaphacts.com/produc) platform, which forms the foundation of [ResearchSpace](https://www.researchspace.org/), and can be used to navigate and visualise CIDOC-CRM compatible RDF data, as well as build custom user interfaces for other linked data applications.

--- a/content/workshops/2019-02-25-TheSpringFramework.md
+++ b/content/workshops/2019-02-25-TheSpringFramework.md
@@ -3,6 +3,8 @@ title: The Spring Framework
 date: '2019-02-25'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D8CF-9/data'
 slides: /files/springframework_slides.pdf
+aliases:
+- /workshops/2019-02-25-TheSpringFramework/
 ---
 
 In the first workshop of 2019, Julia Damerow talked about developing applications using Java and the Spring Framework. Core concepts of Spring were briefly discussed on some of Spring’s projects such as Spring Security and Spring Data.  

--- a/content/workshops/2019-05-20-Front end Development using Vue.md
+++ b/content/workshops/2019-05-20-Front end Development using Vue.md
@@ -2,6 +2,8 @@
 title: Front end Development using Vue
 date: '2019-05-20'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000C-20A1-9/data'
+aliases:
+- /workshops/2019-05-20-Front-end-Development-using-Vue/
 ---
 
 On May 20, 2019, Taylor Quinn talked about starting a Vue.js project using the Vue CLI and Single file component basics.

--- a/content/workshops/2019-09-09-How-to-train-your-new-developers.md
+++ b/content/workshops/2019-09-09-How-to-train-your-new-developers.md
@@ -2,6 +2,8 @@
 title: How to train your new developers?
 date: '2019-09-09'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000C-35D8-5/data'
+aliases:
+- /workshops/2019-09-09-How-to-train-your-new-developers/
 ---
 
 On September 9th, 2019, Itay Zandbank gave a short overview of how his company trains new developers and brings them up to speed on their projects.


### PR DESCRIPTION
addresses #98 

In the initial migration to hugo, we had a non-standard config to preserve case when generating urls which I did not catch.

This update changes that config and adds aliases for all the pages that will be affected by the change (I ran a crawl script to identify pages that would be affected)