### PR TITLE
Moved meetups to news section; tagged all meetups; added meetups to s…

### DIFF
--- a/_vendor/github.com/chipzoller/hugo-clarity/archetypes/post.md
+++ b/_vendor/github.com/chipzoller/hugo-clarity/archetypes/post.md
@@ -16,6 +16,8 @@ codeMaxLines: 10 # Override global value for how many lines within a code block 
 codeLineNumbers: false # Override global value for showing of line numbers within code block.
 figurePositionShow: true # Override global value for showing the figure label.
 showRelatedInArticle: false # Override global value for showing related posts in this series at the end of the content.
+meetup_date: 2024-02-15T15:00:00 # if post is an announcement of a meetup, the date and time of the meetup
+registration: https://zoom.registartion.ink/ # if post is an announcement of a meetup or another event with registration, the link to register. It will show up on the top of the post.
 categories:
   - Technology
 tags:

--- a/config.yaml
+++ b/config.yaml
@@ -12,9 +12,6 @@ menu:
   - name: news
     pageRef: /news/
     weight: 2
-  - name: meetups
-    pageRef: /workshops/
-    weight: 3
   - name: blog
     pageRef: /blog/
     weight: 4

--- a/content/news/2017-12-14-announcing-the-first-virtual-workshop.md
+++ b/content/news/2017-12-14-announcing-the-first-virtual-workshop.md
@@ -4,6 +4,9 @@ date: 2017-12-14T19:30:00
 author: "cthiel"
 excerpt: "Established at DH 2017 Montreal, DHTech aims to support the development and reuse of software in the Digital Humanities by providing a community to exchange knowledge, share expertise, and foster collaboration among Digital Humanities software projects."
 slug: announcing-the-first-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 Established at DH 2017 Montreal, DHTech aims to support the development and reuse of software in the Digital Humanities

--- a/content/news/2018-01-15-ci-cd.md
+++ b/content/news/2018-01-15-ci-cd.md
@@ -1,9 +1,16 @@
 ---
-title: Gitlab CI/CD for Django
-date: '2018-01-1'
+title: "Gitlab CI/CD for Django"
+date: 2018-01-15
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CAFE-4'
 audio: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CAFF-3'
 slides: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CB00-0'
+
+slug: gitlab-ci-cd
+aliases: 
+    - /workshops/2018-01-15-ci-cd/
+tags:
+    - meetup
+    - recording
 ---
 
 Malte will talk about Gitlab CI/CD for Django websites,

--- a/content/news/2018-01-16-announcing-february-virtual-workshop.md
+++ b/content/news/2018-01-16-announcing-february-virtual-workshop.md
@@ -3,6 +3,9 @@ title:  "Announcing the February DHTech Virtual Workshop"
 date: 2018-01-16T09:30:00
 excerpt: The next DHTech Virtual Workshop will be on February 19, 2018 at 8am MST/4pm CET. Robert Casties (MPIWG) will be talking about image servers and IIIF (International Image Interoperability Framework).
 slug: announcing-february-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 The next DHTech Virtual Workshop will be on February 19, 2018 at 8am MST/4pm CET. Robert Casties (MPIWG) will be talking about image servers and IIIF (International Image Interoperability Framework). Robert is the architect and developer of Digilib, a state-less, web-based client-server application for interactive viewing and manipulation of images that is IIIF compliant. IIIF is a set of API specifications to enable interoperability between image repositories.

--- a/content/news/2018-02-19-iiif.md
+++ b/content/news/2018-02-19-iiif.md
@@ -1,9 +1,16 @@
 ---
 title: Image Servers and IIIF
-date: '2018-02-19'
+date: 2018-02-19
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CB02-E'
 audio: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CB03-D'
 slides: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CB04-C'
+
+slug: image-servers-iiif
+aliases: 
+    - /workshops/2018-02-19-iiif/
+tags:
+    - meetup
+    - recording
 ---
 
 Robert talked about Image Servers and IIIF. He presented Digilib a IIIF-compliant image server that he  develops.

--- a/content/news/2018-02-26-announcing-march-virtual-workshop.md
+++ b/content/news/2018-02-26-announcing-march-virtual-workshop.md
@@ -4,6 +4,9 @@ date: 2018-02-26T09:30:00
 author: Julia Damerow
 excerpt: The next DHTech Virtual Workshop will be on March 26, 2018 at 8am MST/5pm CET. Carsten Thiel (Georg-August-Universität Göttingen) will be talking about configuration management.
 slug: announcing-march-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 The next DHTech Virtual Workshop will be on March 26, 2018 at 8am MST/5pm CET. Please note that due to daylight saving time, we will meet an hour later. Carsten Thiel (Georg-August-Universität Göttingen) will be talking about configuration management. He will be touching on topics such as Puppet and his experiences in regards to configuration management. Carsten works as Technology Coordinator DARIAH-DE at the Niedersächsische Staats- und Universitätsbibliothek Göttingen.

--- a/content/news/2018-03-26-config-management.md
+++ b/content/news/2018-03-26-config-management.md
@@ -1,9 +1,16 @@
 ---
 title: Configuration Management
-date: '2018-03-26'
+date: 2018-03-26
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CB06-A'
 audio: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-CB07-9'
 blogpost: https://subugoe.pages.gwdg.de/lab.sub/config-management.html
+
+slug: configuration-management
+aliases: 
+    - /workshops/2018-03-26-config-management/
+tags:
+    - meetup
+    - recording
 ---
 
 Carsten Thiel talked about configuration management. He touched on topics such as Puppet and his experiences in regards to configuration management. Carsten works as Technology Coordinator DARIAH-DE at the Niedersächsische Staats- und Universitätsbibliothek Göttingen.

--- a/content/news/2018-03-28-announcing-april-virtual-workshop.md
+++ b/content/news/2018-03-28-announcing-april-virtual-workshop.md
@@ -4,6 +4,9 @@ date: 2018-04-07T17:30:00
 author: Carsten Thiel
 excerpt: The next DHTech Virtual Workshop will be on April 23, 2018 at 8am MST/5pm CET. Julia Damerow (Arizona State University) will talk about Apache Kafka and the Giles Ecosystem.
 slug: announcing-april-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 The next DHTech Virtual Workshop will be on April 23, 2018 at 8am MST/5pm CET.

--- a/content/news/2018-04-23-apache-kafka.md
+++ b/content/news/2018-04-23-apache-kafka.md
@@ -2,6 +2,13 @@
 title: Apache Kafka and the Giles Ecosystem
 date: '2018-04-23'
 recording: 'https://hdl.handle.net/21.11113/0000-000B-D070-B@data'
+
+slug: apache-kafka-giles
+aliases: 
+    - /workshops/2018-04-23-apache-kafka/
+tags:
+    - meetup
+    - recording
 ---
 
 Julia Damerow talked about Apache Kafka and how it is used in the Giles Ecosystem.

--- a/content/news/2018-06-04-announcing-june-virtual-workshop.md
+++ b/content/news/2018-06-04-announcing-june-virtual-workshop.md
@@ -4,6 +4,9 @@ date: 2018-05-30T17:00:00
 author: Carsten Thiel
 excerpt: The next DHTech Virtual Workshop will be on June 04, 2018 at 8am MST/5pm CEST. Peter Gietz (DAASI International) will talk about Authentication and Authorization.
 slug: announcing-june-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 The next DHTech Virtual Workshop will be on June 04, 2018 at 8am MST/5pm CEST.

--- a/content/news/2018-06-04-authentication.md
+++ b/content/news/2018-06-04-authentication.md
@@ -3,6 +3,13 @@ title: Authentication and Authorization
 date: '2018-06-04'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D213-2/data'
 audio: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D212-3/data'
+
+slug: authentication-authorization
+aliases: 
+    - /workshops/2018-06-04-authentication/
+tags:
+    - meetup
+    - recording
 ---
 
 Peter Gietz talked about Authentication and Authorization. he is the CEO of DAASI International and has been working with federated identity management for decades.

--- a/content/news/2018-07-02-announcing-july-virtual-workshop.md
+++ b/content/news/2018-07-02-announcing-july-virtual-workshop.md
@@ -4,6 +4,9 @@ date: 2018-07-02T10:00:00
 author: Julia Damerow
 excerpt: The next DHTech Virtual Workshop will be on July 09, 2018 at 8am MST/5pm CEST. Yoann Moranville will give an introduction to WordPress plugins.
 slug: announcing-july-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 The next DHTech Virtual Workshop will be on July 9, 2018 at 8am MST/5pm CEST.

--- a/content/news/2018-07-09-wordpress.md
+++ b/content/news/2018-07-09-wordpress.md
@@ -3,6 +3,13 @@ title: Introduction to WordPress plugins
 date: '2018-07-09'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D215-0/data'
 audio: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D216-F/data'
+
+slug: wordpress
+aliases: 
+    - /workshops/2018-07-09-wordpress/
+tags:
+    - meetup
+    - recording
 ---
 
 Yoann Moranville gave an *Introduction to WordPress plugins*.

--- a/content/news/2018-10-09-announcing-october-virtual-workshop.md
+++ b/content/news/2018-10-09-announcing-october-virtual-workshop.md
@@ -4,6 +4,9 @@ date: 2018-10-09T10:00:00
 author: Julia Damerow
 excerpt: The next DHTech Virtual Workshop will be on October 15, 2018 at 7am MST/4pm CEST. Florian Kräutli will run the workshop. Its topic is "CIDOC-CRM by Practice."
 slug: announcing-october-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 The next DHTech Virtual Workshop will be on October 15, 2018 at 7am MST/4pm CEST held by Florian Kräutli. The topic of the workshop will be "CIDOC-CRM by Practice." Florian will give an introduction to the practical application of CIDOC-CRM for creating Linked Data applications. He will demonstrate how to convert existing data to CIDOC-CRM and subsequently visualize it within a Linked Data platform. Florian coordinates digital research activities at the Max Planck Institute for the History of Science. More info will follow soon.

--- a/content/news/2018-10-15-CIDOC-CRMbyPractice.md
+++ b/content/news/2018-10-15-CIDOC-CRMbyPractice.md
@@ -11,6 +11,7 @@ aliases:
 tags:
     - meetup
     - recording
+---
 
 In this webinar Florian Kräutli showed how to use the [X3ML Toolkit](https://www.ics.forth.gr/isl/index_main.php?l=e&c=721) to build a [CIDOC-CRM model](http://www.cidoc-crm.org/) based on existing XML data. We can then use the same tool to convert the data to RDF and ingest it into a linked data platform. He demonstrated the [Metaphactory](https://www.metaphacts.com/produc) platform, which forms the foundation of [ResearchSpace](https://www.researchspace.org/), and can be used to navigate and visualise CIDOC-CRM compatible RDF data, as well as build custom user interfaces for other linked data applications.
 

--- a/content/news/2018-10-15-CIDOC-CRMbyPractice.md
+++ b/content/news/2018-10-15-CIDOC-CRMbyPractice.md
@@ -4,6 +4,13 @@ date: '2018-10-15'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D236-B/data'
 audio: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D235-C/data'
 excerpt: "In this webinar Florian Kräutli showed how to use the [X3ML Toolkit](https://www.ics.forth.gr/isl/index_main.php?l=e&c=721) to build a [CIDOC-CRM model](link to http://www.cidoc-crm.org/) based on existing XML data."
+
+slug: cidoc-crm-by-practice
+aliases: 
+    - /workshops/2018-10-15-CIDOC-CRMbyPractice/
+tags:
+    - meetup
+    - recording
 ---
 
 In this webinar Florian Kräutli showed how to use the [X3ML Toolkit](https://www.ics.forth.gr/isl/index_main.php?l=e&c=721) to build a [CIDOC-CRM model](http://www.cidoc-crm.org/) based on existing XML data. We can then use the same tool to convert the data to RDF and ingest it into a linked data platform. He demonstrated the [Metaphactory](https://www.metaphacts.com/produc) platform, which forms the foundation of [ResearchSpace](https://www.researchspace.org/), and can be used to navigate and visualise CIDOC-CRM compatible RDF data, as well as build custom user interfaces for other linked data applications.

--- a/content/news/2018-11-09-announcing-november-virtual-workshop.md
+++ b/content/news/2018-11-09-announcing-november-virtual-workshop.md
@@ -3,6 +3,9 @@ title:  "Announcing the November DHTech Virtual Workshop"
 date: 2018-10-16T10:00:00
 author: Julia Damerow
 slug: announcing-november-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 We are currently planning the next workshop. Please check back later for more info.

--- a/content/news/2019-02-05-announcing-dhtech-virtual-workshop.md
+++ b/content/news/2019-02-05-announcing-dhtech-virtual-workshop.md
@@ -5,6 +5,9 @@ author: Julia Damerow
 slug: announcing-dhtech-virtual-workshop
 aliases:
 - /announcement/2019/02/28/announcing-march-virtual-workshop/
+
+tags:
+    - announcement
 ---
 
 In the first workshop of 2019 on February 25 at 8am MST/4pm CEST, Julia Damerow will talk about developing applications using Java and the Spring Framework. We will talk about the core concepts of Spring and briefly touch on some of Spring’s projects such as Spring Security and Spring Data.

--- a/content/news/2019-02-25-TheSpringFramework.md
+++ b/content/news/2019-02-25-TheSpringFramework.md
@@ -3,6 +3,13 @@ title: The Spring Framework
 date: '2019-02-25'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000B-D8CF-9/data'
 slides: /files/springframework_slides.pdf
+
+slug: spring-framework
+aliases: 
+    - /workshops/2019-02-25-TheSpringFramework/
+tags:
+    - meetup
+    - recording
 ---
 
 In the first workshop of 2019, Julia Damerow talked about developing applications using Java and the Spring Framework. Core concepts of Spring were briefly discussed on some of Spring’s projects such as Spring Security and Spring Data.  

--- a/content/news/2019-05-20-Front end Development using Vue.md
+++ b/content/news/2019-05-20-Front end Development using Vue.md
@@ -2,6 +2,13 @@
 title: Front end Development using Vue
 date: '2019-05-20'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000C-20A1-9/data'
+
+slug: fronend-development-using-vue
+aliases: 
+    - /workshops/2019-05-20-Front-end-Development-using-Vue/
+tags:
+    - meetup
+    - recording
 ---
 
 On May 20, 2019, Taylor Quinn talked about starting a Vue.js project using the Vue CLI and Single file component basics.

--- a/content/news/2019-05-20-announcing-may-workshop.md
+++ b/content/news/2019-05-20-announcing-may-workshop.md
@@ -4,6 +4,9 @@ date: 2019-04-09T10:00:00
 author: Julia Damerow
 excerpt: On May 20, 2019, Taylor Quinn will talk about starting a Vue.js project using the Vue CLI and Single file component basics
 slug: announcing-may-workshop
+
+tags:
+    - announcement
 ---
 
 On May 20, 2019, Taylor Quinn will talk about starting a Vue.js project using the Vue CLI and Single file component basics. He will show how to set up and use axios to make Ajax calls. Taylor is a Software Engineer in the Digital Innovation Group at ASU where he specializes on Python and Django development using Vue.js.

--- a/content/news/2019-08-23-announcing-september-workshop.md
+++ b/content/news/2019-08-23-announcing-september-workshop.md
@@ -4,6 +4,9 @@ date: 2019-08-23T8:00:00
 author: Julia Damerow
 excerpt: On September 9, 2019 Itay Zandbank will talk about how his company trains new developers followed by a group discussion.
 slug: announcing-september-workshop
+
+tags:
+    - announcement
 ---
 
 On September 9, 2019 Itay Zandbank will give a short overview of how his company trains new developers and brings them up to speed on their projects. His presentation will be followed by a group discussion. Itay is the CEO and founder of The Research Software Company, a company that provides services for science and humanities research labs from coding to data management.

--- a/content/news/2019-09-09-How-to-train-your-new-developers.md
+++ b/content/news/2019-09-09-How-to-train-your-new-developers.md
@@ -2,6 +2,13 @@
 title: How to train your new developers?
 date: '2019-09-09'
 recording: 'https://repository.de.dariah.eu/1.0/dhcrud/21.11113/0000-000C-35D8-5/data'
+
+slug: train-new-developers
+aliases: 
+    - /workshops/2019-09-09-How-to-train-your-new-developers/
+tags:
+    - meetup
+    - recording
 ---
 
 On September 9th, 2019, Itay Zandbank gave a short overview of how his company trains new developers and brings them up to speed on their projects.

--- a/content/news/2019-11-13-announcing-november-workshop.md
+++ b/content/news/2019-11-13-announcing-november-workshop.md
@@ -5,6 +5,9 @@ author: Julia Damerow
 published: true
 excerpt: On November 13, at 10am ET/4pm CET, we will be discussing the idea to propose an ADHO Special Interest Group.
 slug: announcing-november-workshop
+
+tags:
+    - announcement
 ---
 
 On November 13, at 10am ET/4pm CET, we will be discussing the idea to propose an ADHO Special Interest Group (SIG) (see http://adho.org/sigs for information on ADHO SIGs). If you are interested in participating in this discussion and a potential proposal, please join us as at [Zoom](https://zoom.us/j/755179791).

--- a/content/news/2019-12-06-announcing-december-workshop.md
+++ b/content/news/2019-12-06-announcing-december-workshop.md
@@ -4,6 +4,9 @@ date: 2019-12-06T10:00:00
 author: Julia Damerow
 excerpt: On December 17, at 10am ET/4pm CET, we will be discussing the ADHO Special Interest Group proposal.
 slug: announcing-december-workshop
+
+tags:
+    - announcement
 ---
 
 On December 17, at 10am ET/4pm CET, we will be discussing the ADHO Special Interest Group (SIG) proposal. If you are interested in participating in this discussion and the SIG proposal submission, please join our Slack channel #sig-planning and attend the webinar at [Zoom](https://zoom.us/j/755179791).

--- a/content/news/2019-28-02-announcing-march-virtual-workshop.md
+++ b/content/news/2019-28-02-announcing-march-virtual-workshop.md
@@ -4,6 +4,9 @@ date: 2019-02-28T10:00:00
 author: Julia Damerow
 category: announcement
 slug: announcing-march-virtual-workshop
+
+tags:
+    - announcement
 ---
 
 We are currently planning the next workshop. Please check back later for more info.

--- a/content/news/2020-01-10-announcing-january-workshop.md
+++ b/content/news/2020-01-10-announcing-january-workshop.md
@@ -5,6 +5,9 @@ author: Julia Damerow
 published: true
 excerpt: On Thu, Jan. 23, 2020 at 10am ET/4pm CET, we will be discussing how to build local DH RSE communities. We will talk about questions such as how you can go about finding like-minded people at your institution or area or what methods have people successfully applied to build a DH RSE community?
 slug: announcing-january-workshop
+
+tags:
+    - announcement
 ---
 
 Are you the lone DH RSE wolf in your group? Do you think there must be others like you at your institution and would like to connect? Or are you working in a group of DH RSEs or have you successfully mastered creating a local DH RSE community? On Thu, Jan. 23, 2020 at 10am ET/4pm CET, we will be discussing how to build local DH RSE communities. What have others done to successfully connect with like-minded people? How to make your institution aware of your type of work and its importance to research? We invite anyone interested in that topic to join our discussion on [Zoom](https://zoom.us/j/755179791).

--- a/content/news/2020-02-07-announcing-february-workshop.md
+++ b/content/news/2020-02-07-announcing-february-workshop.md
@@ -5,6 +5,9 @@ author: Julia Damerow
 published: true
 excerpt: On Thu, Feb. 27, 10am ET/4pm CET, we will be talking about how different projects manage their deployment, release, and packaging workflows. We will be discussing the different ways code can be release and deployed and everything that surrounds that topic.
 slug: announcing-february-workshop
+
+tags:
+    - announcement
 ---
 
 On Thu, Feb. 27, 10am ET/4pm CET, we will be talking about how different projects manage their deployment, release, and packaging workflows. Do you use a CI/CD server? Do you release your code through pip? Do you have shell scripts to manage your workflows? Maybe you use Ansible or Docker? Or how else do you manage your workflows? This webinar will be a discussion of the different ways code can be release and deployed and everything that surrounds that topic. Come join us if you want to share your experiences, want to learn from what others have faced, or are simply curious what all the fuss is about. Come with questions, stories, fun facts! There won’t be a presenter for this webinar, but we hope for contributions from the webinar participants for a broad overview of what’s out there and what is being used. Please join us on [Zoom](https://zoom.us/j/755179791).

--- a/content/news/2020-02-27-deploy-packaging.md
+++ b/content/news/2020-02-27-deploy-packaging.md
@@ -1,7 +1,14 @@
 ---
 title: 'Deployment, Release, and Packaging Workflows'
 date: '2020-02-27'
+meetup_date: 2020-02-27
 excerpt: "On February 27, 2020, a total of 11 DHTech members met for a webinar on the topic of deployment, release, and packaging workflows. Several people described the workflows and tools they employ at their organizations followed by a lively (and interesting) discussion of questions and answers."
+
+slug: deploy-packaging
+aliases: 
+    - /workshops/2020-02-27-deploy-packaging/
+tags:
+    - meetup
 ---
 
 ## Webinar Summary

--- a/content/news/2022-02-17-lightning-talks.md
+++ b/content/news/2022-02-17-lightning-talks.md
@@ -1,8 +1,16 @@
 ---
 title: 'Community Projects Lightning Talks'
 date: '2022-02-17'
+meetup_date: 2022-02-17
 excerpt: "On February 17, 2022, members from DHTech came together to learn about some of the projects of community members."
 recording: https://drive.google.com/file/d/198evThvPZ38mlSjntyBBaD3gCOB3AHnH/view?usp=sharing
+
+slug: lightning-talks
+aliases: 
+    - /workshops/2022-02-17-lightning-talks/
+tags:
+    - meetup
+    - recording
 ---
 
 ## Webinar Summary

--- a/content/news/2022-04-13-announcing-april-meetup.md
+++ b/content/news/2022-04-13-announcing-april-meetup.md
@@ -1,10 +1,15 @@
 ---
 layout: post
-title: April DHTech Meetup
+title: April DHTech Meetup on Documentation
 date: 2022-04-13T12:00:00
+meetup_date: 2022-04-21
 author: Julia Damerow
 excerpt: On April 21, 2022 at 9am, we will be discussing software documentation (technical, API, end user, etc). Come join us!
 slug: announcing-april-meetup
+
+tags:
+    - announcement
+    - meetup
 ---
 The April DHTech meetup will take place on **April 21, 2022 at 9am ET/3pm CEST**. The topic of the meetup will be the various types of **documentation (technical, API, end user, etc)** that might be required when developing software. We plan to discuss different solutions and workflows to write, distribute, and maintain documentation. Have you mastered documenting all aspects of your code? Are you struggling to at least keep a minimum of documentation up to date? Are you somewhere in between? We want to hear and learn from you! All participants are invited to **share their documentation processes and experiences**. Please fill out [this form](https://forms.gle/XowNEod5mzMpsQnB6) if you would like to briefly talk about how you or your team handles documentation, the lessons you’ve learnt, or your favorite documentation tool (no more than 2 minutes and one slide).
 

--- a/content/news/2022-12-20-announcing-code-review-workshop.md
+++ b/content/news/2022-12-20-announcing-code-review-workshop.md
@@ -5,6 +5,9 @@ date: 2022-12-20T10:00:00
 author: Julia Damerow
 excerpt: The Code Review Working Group will hold a workshop on January 18, 2023 at 11am ET/5pm CET.
 slug: announcing-code-review-workshop
+
+tags:
+    - announcement
 ---
 
 Do you have a piece of code you would like to submit for review but you don’t know if it’s ready? Or maybe you don’t know how to get it ready? Or would you like to review some code but would like to talk about the process first? Then this workshop is for you! If you would like to submit code for review, we will work with you to get your code in shape for submission (make sure it’s on GitHub, go over what is needed for the submission, etc). If you would like to know more about what it means to become a reviewer, we will answer any questions you might have! Register for [this virtual workshop here](https://asu.zoom.us/meeting/register/tZYkdu2qqj0uHdJErFAmxVjQVtyjS0gE9iiu).

--- a/content/news/2023-03-30-announcing-april-meetup.md
+++ b/content/news/2023-03-30-announcing-april-meetup.md
@@ -1,11 +1,15 @@
 ---
 layout: post
-title: DHTech April Meetup
+title: DHTech April Meetup about the Princeton Geniza Project
 slug: announcing-april-meetup
 date: 2023-03-30T10:00:00
+meetup_date: 2023-04-20
 author: Julia Damerow
 excerpt: In our April meetup on April 20, 9am ET/3pm CET Rebecca Sutton Koeser will talk about one of her projects.
 
+tags:
+    - announcement
+    - meetup
 ---
 
 Rebecca will talk about her work on version four of the [Princeton Geniza Project](https://geniza.princeton.edu/) (PGP). Over the course of a two-year research partnership with Marina Rustow and the Princeton Geniza Lab, they de-siloed data (metadata and transcription text), improved researcher workflow, designed and built a new search interface, implemented a new tool ([annotorious-tahqiq](https://github.com/Princeton-CDH/annotorious-tahqiq)) for creating and editing transcriptions that is designed for RTL languages from the start; incorporated IIIF images from a variety of different institutions, have preliminary dataset exports planned to be used for eventual dataset publication. Technical challenges include: working with data from a long-running project (PGP dates back to the 80s); mixed scripts and bidirectional text (Hebrew, Arabic, Judaeo-Arabic); dates from different historical calendars; displaying text and image together when both are optional; transcription workflow and data format, etc.

--- a/content/news/2023-09-28-announcing-october-meetup.md
+++ b/content/news/2023-09-28-announcing-october-meetup.md
@@ -1,7 +1,8 @@
 ---
 layout: post
-title: DHTech October Meetup
+title: DHTech October Meetup on Education and Training
 date: 2023-09-28T15:00:00
+meetup_date: 2023-10-05
 author: DHTech
 thumbnail: /images/posts/meetup.jpeg
 featureImage: /images/posts/meetup.jpeg

--- a/content/news/2024-01-25-announcing-february-meetup.md
+++ b/content/news/2024-01-25-announcing-february-meetup.md
@@ -2,6 +2,8 @@
 layout: post
 title: DHTech February Meetup on Agent-Based Modeling
 date: 2024-01-25T15:00:00
+meetup_date: 2024-02-15T15:00:00
+registration: https://asu.zoom.us/meeting/register/tZElduuprjsvEtFkc0xgDwpm5CVREJaBQDNT
 author: DHTech
 thumbnail: /images/posts/meetup.jpeg
 featureImage: /images/posts/meetup.jpeg

--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -18,6 +18,17 @@
     <span class="post_date">
       {{ .Date.Format (default "Jan 2, 2006" $.Site.Params.dateFormat) -}}
     </span>
+    {{ if .Params.meetup_date }}
+    {{- if ($scratch.Get "writeSeparator") }}&nbsp;· {{ end }}
+    <span>{{ partial "sprite" (dict "icon" "calendar") }}</span>
+      <span class="post_date">
+      Meetup date: {{ time.Format "Jan 2, 2006 on 9:00 AM"  .Params.meetup_date -}}
+    </span>
+    {{ end }}
+    {{ if .Params.registration }}
+    {{- if ($scratch.Get "writeSeparator") }}&nbsp;· &nbsp;{{ end }}
+      <a href="{{.Params.registration}}">Register</a>
+    {{ end }}
     {{- $scratch.Set "writeSeparator" true }}
   {{- end }}
   {{- if $showReadTime }}

--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -26,10 +26,12 @@
     </span>
     {{ end }}
     {{ if .Params.registration }}
-    {{- if ($scratch.Get "writeSeparator") }}&nbsp;· &nbsp;{{ end }}
-      <a href="{{.Params.registration}}">Register</a>
+    <span>
+    {{- if ($scratch.Get "writeSeparator") }}&nbsp;· {{ end }}
+      <a class="post_tag button " href="{{.Params.registration}}">Register</a>
     {{ end }}
     {{- $scratch.Set "writeSeparator" true }}
+    </span>
   {{- end }}
   {{- if $showReadTime }}
     <span class="post_time">{{ if ($scratch.Get "writeSeparator") }} · {{ end }}{{ T "reading_time" . }}</span>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -78,6 +78,24 @@
       </li>
       {{- end }}
     </ul>
+
+    <h2 class="mt-4">Meetups</h2>
+    <ul class="flex-column">
+      {{- range first 3 (site.Taxonomies.tags.Get "meetup") }}
+      <li>
+        <a href="{{ .RelPermalink }}" class="nav-link" title="{{ .Title }}">
+          
+          {{ if .Params.meetup_date }}
+          {{ $meetupTime := .Params.meetup_date | time }}
+          {{ if lt time.Now $meetupTime }}<b>[Upcoming]</b>{{end}}
+          {{ end}}
+          {{ .Title | markdownify }} {{ if .Params.meetup_date }} ({{ time.Format "Jan 2006" .Params.meetup_date }}){{ end }}
+        </a>
+      </li>
+      {{- end }}
+    </ul>
+    <p><a href='{{ ref . "/tags/meetup" }}'>Browse all meetups.</a></p>
+
     {{- $tagsLimit := (default 100 $s.numberOfTagsShown) }}
     {{- range $key, $value := .Site.Taxonomies }}
     {{- if gt $value 0 }}
@@ -117,23 +135,6 @@
     </div>
     {{- end }}
     {{- end }}
-
-    <h2 class="mt-4">Meetups</h2>
-    <ul class="flex-column">
-      {{- range first 5 (site.Taxonomies.tags.Get "meetup") }}
-      <li>
-        <a href="{{ .RelPermalink }}" class="nav-link" title="{{ .Title }}">
-          
-          {{ if .Params.meetup_date }}
-          {{ $meetupTime := .Params.meetup_date | time }}
-          {{ if lt time.Now $meetupTime }}<b>[Upcoming]</b>{{end}}
-          {{ end}}
-          {{ .Title | markdownify }} {{ if .Params.meetup_date }} ({{ time.Format "Jan 2006" .Params.meetup_date }}){{ end }}
-        </a>
-      </li>
-      {{- end }}
-      <li><a href='{{ ref . "/tags/meetup" }}'>All meetups...</a></li>
-    </ul>
 
     <div class="subscribe">
       <h2>Subscribe via RSS</h2>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -117,6 +117,24 @@
     </div>
     {{- end }}
     {{- end }}
+
+    <h2 class="mt-4">Meetups</h2>
+    <ul class="flex-column">
+      {{- range first 5 (site.Taxonomies.tags.Get "meetup") }}
+      <li>
+        <a href="{{ .RelPermalink }}" class="nav-link" title="{{ .Title }}">
+          
+          {{ if .Params.meetup_date }}
+          {{ $meetupTime := .Params.meetup_date | time }}
+          {{ if lt time.Now $meetupTime }}<b>[Upcoming]</b>{{end}}
+          {{ end}}
+          {{ .Title | markdownify }} {{ if .Params.meetup_date }} ({{ time.Format "Jan 2006" .Params.meetup_date }}){{ end }}
+        </a>
+      </li>
+      {{- end }}
+      <li><a href='{{ ref . "/tags/meetup" }}'>All meetups...</a></li>
+    </ul>
+
     <div class="subscribe">
       <h2>Subscribe via RSS</h2>
       <ul>


### PR DESCRIPTION
I hope I did this right. I changed the following:
- Moved all meetup posts to news folder.
- Tagged all meetups as meetups
    - For past meetup announcement posts where a post about the meetup with recording existed, I tagged the announcement of the meetup as `meetup` and the announcement as `announcement`
    - For current meetup announcement (where we don't have the recording post afterwards anymore), I tagged the announcement as meetup.
- I've added the last 5 meetups to the sidebar
- I've added a "meetup" property to the past fews meetups that is shown in the sidebar
- I've added a "registration" property to the current meetup announcement
- The post page now shows meetup date and registration link if there is one at the top

See what you think :)