### PR TITLE
Add half-width and quarter-width classes for images

### DIFF
--- a/assets/sass/_custom.sass
+++ b/assets/sass/_custom.sass
@@ -55,8 +55,18 @@ div.subscribe
 
 
 .half-width
-	max-width: 500px
+	max-width: 50%
+	float: left
+	margin-right: 2rem
+	display: block
 	height:auto
+.quarter-width
+	max-width: 25%
+	float: left
+	margin-right: 2rem
+	display: block
+	height:auto
+
 
 // font used in new dhtech logo; used in RSK post about creating logo
 @font-face


### PR DESCRIPTION
These classes are primarily meant for images and by default float on the left with 2 rem of margin on its right.